### PR TITLE
Fixed bug in @click.argument() usage. Changed to @click.option()

### DIFF
--- a/bayleef/__init__.py
+++ b/bayleef/__init__.py
@@ -57,8 +57,8 @@ config = None
 os.makedirs(os.path.join(str(Path.home()), ".bayleef"), exist_ok=True)
 if not os.path.isfile(os.path.join(str(Path.home()), ".bayleef", "config.yaml")):
     copyfile(config_file, os.path.join(str(Path.home()), ".bayleef", "config.yaml"))
-    config = dotdict(yaml.load(open(config_file)))
+    config = dotdict(yaml.load(open(config_file), Loader=yaml.BaseLoader))
 else:
-    config = dotdict(yaml.load(open(os.path.join(str(Path.home()), ".bayleef", "config.yaml"))))
+    config = dotdict(yaml.load(open(os.path.join(str(Path.home()), ".bayleef", "config.yaml")), Loader=yaml.BaseLoader))
 
 config_file = os.path.join(str(Path.home()), ".bayleef", "config.yaml")

--- a/bayleef/scripts/cli.py
+++ b/bayleef/scripts/cli.py
@@ -408,7 +408,7 @@ def sbatch_master(input, bayleef_data, add_option, njobs, **options):
 
 @click.command()
 @click.argument("input", required=True)
-@click.argument("--bayleef_data", "-d", default=config.data)
+@click.option("--bayleef_data", "-d", default=config.data)
 @click.option("-r", is_flag=True, help="Set to recursively glob .HDF files (Warning: Every .HDF file under the directory will be treated as a Master file)")
 def load_master(input, bayleef_data, r):
     """


### PR DESCRIPTION
I get `TypeError: Arguments take exactly one parameter declaration, got 2` when simply running `bayleef --help`

Changing one of the @click.argument() to @click.option() fixes error. 

-- second commit
fixed yaml loader warning